### PR TITLE
Use bash from env for better portability

### DIFF
--- a/openwrt_build.sh
+++ b/openwrt_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # the name of the app
 CHIPAPP_NAME="p44mbrd"

--- a/pregen_code.sh
+++ b/pregen_code.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Details see: file:///Users/luz/Code/looking_at_external_stuff/connectedhomeip/docs/code_generation.md
 


### PR DESCRIPTION
Hi
According to [Stackoverflow](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang#10383546) it looks like the portability of the scripts could be improved by having this new style for the bash shebang.